### PR TITLE
Alligned images in new collections section perfectly

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -166,7 +166,7 @@ function Home() {
           </p>
         </header>
 
-        <div className="mt-8 flex flex-col items-center justify-center sm:flex-row gap-5">
+        <div className="mt-8 flex flex-col justify-center sm:flex-row gap-5">
           <div className="flex gap-5 w-2/3">
             <img
               src="./images/winter3.jpg"
@@ -185,13 +185,13 @@ function Home() {
             <img
               src="./images/winter2.jpg"
               alt=""
-              className="w-full transition duration-500 group-hover:opacity-90"
+              className="w-full h-full transition duration-500 group-hover:opacity-90"
             />
 
             <img
               src="./images/winter4.jpg"
               alt=""
-              className="w-full transition duration-500 "
+              className="w-full h-full transition duration-500 "
             />
           </div>
         </div>


### PR DESCRIPTION
Fixes #95 

Sizes of image in new collections section are now alligned perfectly as shown in below screenshot
![image](https://github.com/pooranjoyb/popShop/assets/108569153/d23744f6-3f51-4c0a-b50a-7aab6a1b94f5)

[Bug]

- My code follows the style guidelines of this project
- I have performed a self-review of my code
- My changes generate no new warnings
