### PR TITLE
added buttons on Products page and home screen

### DIFF
--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -1,4 +1,6 @@
 import { useNavigate } from "react-router-dom";
+import Button from "./Button";
+import { toast } from 'react-toastify';
 
 interface Data {
   name: string;
@@ -9,23 +11,34 @@ interface Data {
 
 function Product({ name, image, price, desc }: Data) {
   const navigate = useNavigate();
-
+  const addToCart = () => {
+    // logic for adding in cart
+    toast.success('Added to Cart', { autoClose: 2000 });
+  };
   const handleNavigate = () => {
     navigate("/home/product", { state: { name, image, price, desc } });
   };
   return (
     <>
-      <button onClick={handleNavigate}>
-        <div className="aspect-h-1 aspect-w-1 w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-h-8 xl:aspect-w-7">
-          <img
-            src={image}
-            alt="Tall slender porcelain bottle with natural clay textured body and cork stopper."
-            className="h-full w-full object-cover object-center group-hover:opacity-75 hover:duration-300"
-          />
+      <div className="flex flex-col">
+        <button onClick={handleNavigate}>
+          <div className="aspect-h-1 aspect-w-1 w-full overflow-hidden rounded-lg bg-gray-200 xl:aspect-h-8 xl:aspect-w-7">
+            <img
+              src={image}
+              alt="Tall slender porcelain bottle with natural clay textured body and cork stopper."
+              className="h-full w-full object-cover object-center group-hover:opacity-75 hover:duration-300"
+            />
+          </div>
+          <h3 className="mt-4 text-sm text-gray-700">{name}</h3>
+          <p className="mt-1 text-lg font-medium text-gray-900">${price}</p>
+        </button>
+        <div className="flex flex-auto justify-between p-8 space-x-24">
+
+          <Button text="Add to Cart" color="mygreen" hover="myred" onClick={addToCart} />
+          <Button text="Buy Now" color="myyellow" hover="myred" />
         </div>
-        <h3 className="mt-4 text-sm text-gray-700">{name}</h3>
-        <p className="mt-1 text-lg font-medium text-gray-900">${price}</p>
-      </button>
+      </div>
+      
     </>
   );
 }

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import Button from "./Button";
 import { toast } from 'react-toastify';
+import { MdOutlineShoppingCart } from "react-icons/md";
 
 interface Data {
   name: string;
@@ -34,7 +35,7 @@ function Product({ name, image, price, desc }: Data) {
         </button>
         <div className="flex flex-auto justify-between p-8 space-x-24">
 
-          <Button text="Add to Cart" color="mygreen" hover="myred" onClick={addToCart} />
+          <MdOutlineShoppingCart className="flex m-auto h-10 w-10" onClick={addToCart} />
           <Button text="Buy Now" color="myyellow" hover="myred" />
         </div>
       </div>

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -33,7 +33,7 @@ function Product({ name, image, price, desc }: Data) {
           <h3 className="mt-4 text-sm text-gray-700">{name}</h3>
           <p className="mt-1 text-lg font-medium text-gray-900">${price}</p>
         </button>
-        <div className="flex flex-auto justify-between p-8 space-x-24">
+        <div className="flex flex-auto justify-between px-4 pb-4 space-x-24">
 
           <MdOutlineShoppingCart className="flex m-2 h-10 w-10" onClick={addToCart} />
           

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -35,7 +35,8 @@ function Product({ name, image, price, desc }: Data) {
         </button>
         <div className="flex flex-auto justify-between p-8 space-x-24">
 
-          <MdOutlineShoppingCart className="flex m-auto h-10 w-10" onClick={addToCart} />
+          <MdOutlineShoppingCart className="flex m-2 h-10 w-10" onClick={addToCart} />
+          
           <Button text="Buy Now" color="myyellow" hover="myred" />
         </div>
       </div>


### PR DESCRIPTION
I've added 'Buy Now' and 'Add to Cart' buttons to the product pages, ensuring they align with the website's theme and maintain good color contrast for accessibility.
Fixes #55 


This pull request introduces 'Buy Now' and 'Add to Cart' buttons that are visually consistent with the website's design and optimized for various screen sizes.
![image](https://github.com/pooranjoyb/popShop/assets/108569153/c393b14e-576f-4cb2-884d-121fb7bd0754)


My code follows the style guidelines of this project
I have performed a self-review of my code
I have commented my code, particularly in hard-to-understand areas
My changes generate no new warnings
New and existing unit tests pass locally with my changes
