### PR TITLE
fix: remove duplicate error rendering and fix Google OAuth redirect URL in Auth.tsx

### DIFF
--- a/src/pages/Auth/Auth.tsx
+++ b/src/pages/Auth/Auth.tsx
@@ -137,7 +137,7 @@ function Auth() {
       await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.href}oauth`,
+          redirectTo: `${window.location.origin}/auth/oauth`,
         },
       });
     } catch (err) {
@@ -521,17 +521,6 @@ function Auth() {
                       onClick={togglePasswordVisibility}
                       className="absolute right-3 top-10 cursor-pointer"
                     />
-                    {errors.password && (
-                      <ul
-                        className="px-2 text-xs mt-1"
-                        style={{ color: "red" }}
-                      >
-                        {errors.password.map((error, index) => (
-                          <li key={index}>{error}</li>
-                        ))}
-                      </ul>
-                    )}
-
                     {errors.password && (
                       <ul
                         className="px-2 text-xs mt-1"


### PR DESCRIPTION
## Bugs Fixed

### 1. Duplicate `errors.password` rendering
Password validation errors were rendered twice in the JSX because the same error-mapping block appeared consecutively (lines 525-544). This caused all password-related error messages to appear duplicated to the user.

**Fix:** Removed the duplicate JSX block.

### 2. Incorrect Google OAuth redirect URL
The redirect URL used string concatenation: `` `${window.location.href}oauth` ``. Since `window.location.href` includes the full path (e.g., `http://localhost:5173/auth`), this produced an invalid URL like `http://localhost:5173/authoauth`. The OAuth callback expects `/auth/oauth`.

**Fix:** Use `window.location.origin` to get just the base URL: `` `${window.location.origin}/auth/oauth` ``.