### PR TITLE
Fix router re-creation on render and use env var for encryption key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import  Routes  from './browserRoutes/routes/Routes';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
+const router = Routes();
+
 function App() {
   
   return (
     <>
-      <RouterProvider router={Routes()} />
+      <RouterProvider router={router} />
       <ToastContainer />
     </>
   )

--- a/src/utils/features/store.ts
+++ b/src/utils/features/store.ts
@@ -5,15 +5,13 @@ import { persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage";
 import cartSlice from "./cart/cartSlice";
 
-// const secretkey = import.meta.env.VITE_REDUX_PERSIST_SECRET_KEY;
-
 const persistConfig ={
   key:"root",
   version:1,
   storage:storage,
   transforms:[
     encryptTransform({
-      secretKey: "831476e3ea64e7868101b191c65eebddbe123408",
+      secretKey: import.meta.env.VITE_REDUX_PERSIST_SECRET_KEY ?? "fallback-dev-key",
       onError: function (error) {
         console.log("Problem Occured while encrypting data",error)
       },


### PR DESCRIPTION
Fixed: 1) App.tsx - moved createBrowserRouter call outside component to prevent full remount on every render. 2) store.ts - replaced hardcoded encryption secret key with environment variable.