### PR TITLE
fix: reorder Provider and PersistGate nesting in main.tsx

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,11 +14,11 @@ const persistor = persistStore(store);
 
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-   <React.StrictMode>
-    <PersistGate persistor={persistor}>
+  <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
-    </PersistGate>
-    </React.StrictMode>
+  </React.StrictMode>
 )


### PR DESCRIPTION
### Bug Fixed

`PersistGate` was wrapping `Provider` instead of the other way around. `PersistGate` must be a child of `Provider` so the Redux store context is available during state rehydration. The incorrect ordering could cause the app to render before persisted state is restored, defeating the purpose of PersistGate.

### Changes
- Swapped nesting order so `<Provider>` wraps `<PersistGate>`